### PR TITLE
chore: replace jcenter with mavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,11 +25,6 @@ java {
 
 // We use both Maven Central and our own Artifactory instance, which contains module builds, extra libs, and so on
 repositories {
-    // For development so you can publish binaries locally and have them grabbed from there
-    mavenLocal()
-
-    // External libs - jcenter is Bintray and is supposed to be a superset of Maven Central, but do both just in case
-    jcenter()
     mavenCentral()
 
     // Terasology Artifactory instance for libs not readily available elsewhere plus our own libs


### PR DESCRIPTION
Locally building with ./gradlew build --no-build-cache --refresh-dependencies succeeded.
Adds to MovingBlocks/Terasology#4582