### PR TITLE
build(ci): use SWIG v4.0.2 to build on all platforms

### DIFF
--- a/.github/workflows/allInOne.yml
+++ b/.github/workflows/allInOne.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Build
-        run: ./gradlew build buildNatives
+        run: ./gradlew build buildNatives --info --stacktrace
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/allInOne.yml
+++ b/.github/workflows/allInOne.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - name: Install SWIG
         run: sudo apt-get install swig mingw-w64
+      - run: swig -version
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -34,15 +35,15 @@ jobs:
           path: |
             build/natives/*/*.so
             build/natives/*/*.dll
-            build/natives/*/*.dylib
   build-macos-amd64:
     runs-on: macos-12
     needs: validate-gradle-wrapper
     steps:
-      - name: Install SWIG and CMake
+      - name: Install SWIG
         run: |
+          brew update
           brew install swig
-          brew install cmake
+      - run: swig -version
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -55,22 +56,24 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
       - name: Build
         run: ./gradlew native_macosx_amd64_clang
+      - run: |
+          file build/natives/*/*.dylib
+          md5 build/natives/*/*.dylib
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: macosx-amd64-artifacts
           path: |
-            build/natives/*/*.so
-            build/natives/*/*.dll
             build/natives/*/*.dylib
   build-macos-aarch64:
     runs-on: macos-14
     needs: validate-gradle-wrapper
     steps:
-      - name: Install SWIG and CMake
+      - name: Install SWIG
         run: |
+          brew update
           brew install swig
-          brew install cmake
+      - run: swig -version
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -83,13 +86,14 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
       - name: Build
         run: ./gradlew native_macosx_aarch64_clang
+      - run: |
+          file build/natives/*/*.dylib
+          md5 build/natives/*/*.dylib
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: macosx-aarch64-artifacts
           path: |
-              build/natives/*/*.so
-              build/natives/*/*.dll
               build/natives/*/*.dylib
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/allInOne.yml
+++ b/.github/workflows/allInOne.yml
@@ -85,7 +85,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Build
-        run: ./gradlew build buildNatives --info --stacktrace
+        run: |
+          ./gradlew --stop
+          ./gradlew build buildNatives --info --stacktrace --no-daemon
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/allInOne.yml
+++ b/.github/workflows/allInOne.yml
@@ -3,7 +3,7 @@ name: Build and Publish for all Platforms
 on: [push]
 
 env:
-  SWIG_VERSION: 4.2.1
+  SWIG_VERSION: 4.0.2
 
 jobs:
   validate-gradle-wrapper:
@@ -36,6 +36,8 @@ jobs:
           echo $HOME/swig/bin >> $GITHUB_PATH
       - name: Check SWIG
         run: swig -version
+      - name: Install Ming
+        run: sudo apt-get install -y mingw-w64
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -59,11 +61,26 @@ jobs:
     runs-on: macos-12
     needs: validate-gradle-wrapper
     steps:
-      - name: Install SWIG
+      - name: Restore SWIG from cache
+        id: cache-swig
+        uses: actions/cache@v4
+        with:
+          path: ~/swig
+          key: ${{ runner.os }}-swig-${{ env.SWIG_VERSION }}
+      - name: Build and Install SWIG v${{ env.SWIG_VERSION }}
+        if: steps.cache-swig.outputs.cache-hit != 'true'
         run: |
-          brew update
-          brew install swig
-      - run: swig -version
+          brew install autoconf automake libtool pcre
+          wget https://github.com/swig/swig/archive/refs/tags/v${{ env.SWIG_VERSION }}.tar.gz
+          tar xzf v${{ env.SWIG_VERSION }}.tar.gz
+          cd swig-${{ env.SWIG_VERSION }}
+          ./autogen.sh
+          ./configure --prefix=$HOME/swig
+          make
+          make install
+          echo $HOME/swig/bin >> $GITHUB_PATH
+      - name: Check SWIG
+        run: swig -version
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -89,11 +106,26 @@ jobs:
     runs-on: macos-14
     needs: validate-gradle-wrapper
     steps:
-      - name: Install SWIG
+      - name: Restore SWIG from cache
+        id: cache-swig
+        uses: actions/cache@v4
+        with:
+          path: ~/swig
+          key: ${{ runner.os }}-swig-${{ env.SWIG_VERSION }}
+      - name: Build and Install SWIG v${{ env.SWIG_VERSION }}
+        if: steps.cache-swig.outputs.cache-hit != 'true'
         run: |
-          brew update
-          brew install swig
-      - run: swig -version
+          brew install autoconf automake libtool pcre
+          wget https://github.com/swig/swig/archive/refs/tags/v${{ env.SWIG_VERSION }}.tar.gz
+          tar xzf v${{ env.SWIG_VERSION }}.tar.gz
+          cd swig-${{ env.SWIG_VERSION }}
+          ./autogen.sh
+          ./configure --prefix=$HOME/swig
+          make
+          make install
+          echo $HOME/swig/bin >> $GITHUB_PATH
+      - name: Check SWIG
+        run: swig -version
       - uses: actions/checkout@v4
         with:
           submodules: true

--- a/.github/workflows/allInOne.yml
+++ b/.github/workflows/allInOne.yml
@@ -85,9 +85,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Build
-        run: |
-          ./gradlew --stop
-          ./gradlew build buildNatives --info --stacktrace --no-daemon
+        run: ./gradlew build buildNatives --info --stacktrace
+        env:
+          SWIG: ${{ github.workspace }}/swig/bin/swig
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/allInOne.yml
+++ b/.github/workflows/allInOne.yml
@@ -2,6 +2,9 @@ name: Build and Publish for all Platforms
 
 on: [push]
 
+env:
+  SWIG_VERSION: 4.2.1
+
 jobs:
   validate-gradle-wrapper:
     runs-on: ubuntu-latest
@@ -13,9 +16,26 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate-gradle-wrapper
     steps:
-      - name: Install SWIG
-        run: sudo apt-get install swig mingw-w64
-      - run: swig -version
+      - name: Restore SWIG from cache
+        id: cache-swig
+        uses: actions/cache@v4
+        with:
+          path: ~/swig
+          key: ${{ runner.os }}-swig-${{ env.SWIG_VERSION }}
+      - name: Build and Install SWIG v${{ env.SWIG_VERSION }}
+        if: steps.cache-swig.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get install -y autoconf automake libtool
+          wget https://github.com/swig/swig/archive/refs/tags/v${{ env.SWIG_VERSION }}.tar.gz
+          tar xzf v${{ env.SWIG_VERSION }}.tar.gz
+          cd swig-${{ env.SWIG_VERSION }}
+          ./autogen.sh
+          ./configure --prefix=$HOME/swig
+          make
+          make install
+          echo $HOME/swig/bin >> $GITHUB_PATH
+      - name: Check SWIG
+        run: swig -version
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -27,7 +47,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Build
-        run: ./gradlew buildNatives
+        run: ./gradlew build buildNatives
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -55,7 +75,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Build
-        run: ./gradlew native_macosx_amd64_clang
+        run: ./gradlew build native_macosx_amd64_clang
       - run: |
           file build/natives/*/*.dylib
           md5 build/natives/*/*.dylib
@@ -85,7 +105,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Build
-        run: ./gradlew native_macosx_aarch64_clang
+        run: ./gradlew build native_macosx_aarch64_clang
       - run: |
           file build/natives/*/*.dylib
           md5 build/natives/*/*.dylib

--- a/.github/workflows/allInOne.yml
+++ b/.github/workflows/allInOne.yml
@@ -20,7 +20,7 @@ jobs:
         id: cache-swig
         uses: actions/cache@v4
         with:
-          path: ~/swig
+          path: $GITHUB_WORKSPACE/swig
           key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
       - name: Build and Install SWIG v${{ env.SWIG_VERSION }}
         if: steps.cache-swig.outputs.cache-hit != 'true'
@@ -30,12 +30,12 @@ jobs:
           tar xzf v${{ env.SWIG_VERSION }}.tar.gz
           cd swig-${{ env.SWIG_VERSION }}
           ./autogen.sh
-          ./configure --prefix=$HOME/swig
+          ./configure --prefix=$GITHUB_WORKSPACE/swig
           make
           make install
       - name: Add SWIG to $PATH
         run: |
-          echo $HOME/swig/bin >> $GITHUB_PATH
+          echo $GITHUB_WORKSPACE/swig/bin >> $GITHUB_PATH
           swig -version
       - name: Install Ming
         run: sudo apt-get install -y mingw-w64
@@ -66,7 +66,7 @@ jobs:
         id: cache-swig
         uses: actions/cache@v4
         with:
-          path: ~/swig
+          path: $GITHUB_WORKSPACE/swig
           key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
       - name: Build and Install SWIG v${{ env.SWIG_VERSION }}
         if: steps.cache-swig.outputs.cache-hit != 'true'
@@ -76,12 +76,12 @@ jobs:
           tar xzf v${{ env.SWIG_VERSION }}.tar.gz
           cd swig-${{ env.SWIG_VERSION }}
           ./autogen.sh
-          ./configure --prefix=$HOME/swig
+          ./configure --prefix=$GITHUB_WORKSPACE/swig
           make
           make install
       - name: Add SWIG to $PATH
         run: |
-          echo $HOME/swig/bin >> $GITHUB_PATH
+          echo $GITHUB_WORKSPACE/swig/bin >> $GITHUB_PATH
           swig -version
       - uses: actions/checkout@v4
         with:
@@ -112,7 +112,7 @@ jobs:
         id: cache-swig
         uses: actions/cache@v4
         with:
-          path: ~/swig
+          path: $GITHUB_WORKSPACE/swig
           key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
       - name: Build and Install SWIG v${{ env.SWIG_VERSION }}
         if: steps.cache-swig.outputs.cache-hit != 'true'
@@ -122,12 +122,12 @@ jobs:
           tar xzf v${{ env.SWIG_VERSION }}.tar.gz
           cd swig-${{ env.SWIG_VERSION }}
           ./autogen.sh
-          ./configure --prefix=$HOME/swig
+          ./configure --prefix=$GITHUB_WORKSPACE/swig
           make
           make install
       - name: Add SWIG to $PATH
         run: |
-          echo $HOME/swig/bin >> $GITHUB_PATH
+          echo $GITHUB_WORKSPACE/swig/bin >> $GITHUB_PATH
           swig -version
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/allInOne.yml
+++ b/.github/workflows/allInOne.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v2
-  build-swig:
+  swig:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-12, macos-14]
@@ -51,9 +51,12 @@ jobs:
           brew install pcre
       - name: Check SWIG version
         run: $GITHUB_WORKSPACE/swig/bin/swig -version
-  build-linux-windows-amd64:
-    runs-on: ubuntu-latest
-    needs: [validate-gradle-wrapper, build-swig]
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-12, macos-14]
+    runs-on: ${{ matrix.os }}
+    needs: [validate-gradle-wrapper, swig]
     steps:
       - name: Restore SWIG from cache
         uses: actions/cache@v4
@@ -63,12 +66,14 @@ jobs:
           fail-on-cache-miss: true
       - name: Add SWIG to $PATH
         run: echo "${{ github.workspace }}/swig/bin" >> $GITHUB_PATH
-      - name: Check SWIG version
-        run: |
-          which swig
-          swig -version
-      - name: Install Ming
+      - name: Install MinGW-w64
+        if: runner.os == 'Linux'
         run: sudo apt-get install -y mingw-w64
+      - name: Install pcre
+        if: runner.os == 'macOS'
+        run: brew install pcre
+      - name: Check SWIG version
+        run: swig -version
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -84,93 +89,141 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: linux-windows-amd64-artifacts
+          name: ${{ runner.os }}-${{ runner.arch }}-artifacts
           path: |
             build/natives/*/*.so
             build/natives/*/*.dll
-  build-macos-amd64:
-    runs-on: macos-12
-    needs: [validate-gradle-wrapper, build-swig]
-    steps:
-      - name: Restore SWIG from cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/swig
-          key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
-          fail-on-cache-miss: true
-      - name: Add SWIG to $PATH
-        run: echo "${{ github.workspace }}/swig/bin" >> $GITHUB_PATH
-      - name: Check SWIG version
-        run: |
-          brew install prce
-          which swig
-          swig -version
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
-      - name: Build
-        run: ./gradlew build native_macosx_amd64_clang
-      - run: |
-          file build/natives/*/*.dylib
-          md5 build/natives/*/*.dylib
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: macosx-amd64-artifacts
-          path: |
             build/natives/*/*.dylib
-  build-macos-aarch64:
-    runs-on: macos-14
-    needs: [validate-gradle-wrapper, build-swig]
-    steps:
-      - name: Restore SWIG from cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/swig
-          key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
-          fail-on-cache-miss: true
-      - name: Add SWIG to $PATH
-        run: echo "${{ github.workspace }}/swig/bin" >> $GITHUB_PATH
-      - name: Check SWIG version
-        run: |
-          brew install prce
-          which swig
-          swig -version
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
-      - name: Build
-        run: ./gradlew build native_macosx_aarch64_clang
-      - run: |
-          file build/natives/*/*.dylib
-          md5 build/natives/*/*.dylib
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: macosx-aarch64-artifacts
-          path: |
-              build/natives/*/*.dylib
+    
+  # build-linux-windows-amd64:
+  #   runs-on: ubuntu-latest
+  #   needs: [validate-gradle-wrapper, build-swig]
+  #   steps:
+  #     - name: Restore SWIG from cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: ${{ github.workspace }}/swig
+  #         key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
+  #         fail-on-cache-miss: true
+  #     - name: Add SWIG to $PATH
+  #       run: echo "${{ github.workspace }}/swig/bin" >> $GITHUB_PATH
+  #     - name: Check SWIG version
+  #       run: |
+  #         which swig
+  #         swig -version
+  #     - name: Install Ming
+  #       run: sudo apt-get install -y mingw-w64
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: true
+  #     - name: Set up JDK
+  #       uses: actions/setup-java@v4
+  #       with:
+  #         java-version: '11'
+  #         distribution: 'adopt'
+  #     - name: Setup Gradle
+  #       uses: gradle/actions/setup-gradle@v3
+  #     - name: Build
+  #       run: ./gradlew build buildNatives
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: linux-windows-amd64-artifacts
+  #         path: |
+  #           build/natives/*/*.so
+  #           build/natives/*/*.dll
+  # build-macos-amd64:
+  #   runs-on: macos-12
+  #   needs: [validate-gradle-wrapper, build-swig]
+  #   steps:
+  #     - name: Restore SWIG from cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: ${{ github.workspace }}/swig
+  #         key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
+  #         fail-on-cache-miss: true
+  #     - name: Add SWIG to $PATH
+  #       run: echo "${{ github.workspace }}/swig/bin" >> $GITHUB_PATH
+  #     - name: Check SWIG version
+  #       run: |
+  #         brew install pcre
+  #         which swig
+  #         swig -version
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: true
+  #     - name: Set up JDK
+  #       uses: actions/setup-java@v4
+  #       with:
+  #         java-version: '11'
+  #         distribution: 'adopt'
+  #     - name: Setup Gradle
+  #       uses: gradle/actions/setup-gradle@v3
+  #     - name: Build
+  #       run: ./gradlew build native_macosx_amd64_clang
+  #     - run: |
+  #         file build/natives/*/*.dylib
+  #         md5 build/natives/*/*.dylib
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: macosx-amd64-artifacts
+  #         path: |
+  #           build/natives/*/*.dylib
+  # build-macos-aarch64:
+  #   runs-on: macos-14
+  #   needs: [validate-gradle-wrapper, build-swig]
+  #   steps:
+  #     - name: Restore SWIG from cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: ${{ github.workspace }}/swig
+  #         key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
+  #         fail-on-cache-miss: true
+  #     - name: Add SWIG to $PATH
+  #       run: echo "${{ github.workspace }}/swig/bin" >> $GITHUB_PATH
+  #     - name: Check SWIG version
+  #       run: |
+  #         brew install pcre
+  #         which swig
+  #         swig -version
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: true
+  #     - name: Set up JDK
+  #       uses: actions/setup-java@v4
+  #       with:
+  #         java-version: '11'
+  #         distribution: 'adopt'
+  #     - name: Setup Gradle
+  #       uses: gradle/actions/setup-gradle@v3
+  #     - name: Build
+  #       run: ./gradlew build native_macosx_aarch64_clang
+  #     - run: |
+  #         file build/natives/*/*.dylib
+  #         md5 build/natives/*/*.dylib
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: macosx-aarch64-artifacts
+  #         path: |
+  #             build/natives/*/*.dylib
   publish:
     runs-on: ubuntu-latest
-    needs: [validate-gradle-wrapper,build-linux-windows-amd64, build-macos-amd64, build-macos-aarch64]
+    # needs: [validate-gradle-wrapper,build-linux-windows-amd64, build-macos-amd64, build-macos-aarch64]
+    needs: [validate-gradle-wrapper, swig, build]
     if: github.ref == 'refs/heads/master'
     steps:
-      - name: Install SWIG
-        run: sudo apt-get install swig mingw-w64
+      - name: Restore SWIG from cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/swig
+          key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
+          fail-on-cache-miss: true
+      - name: Add SWIG to $PATH
+        run: echo "${{ github.workspace }}/swig/bin" >> $GITHUB_PATH
+      - name: Check SWIG version
+        run: swig -version
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -187,10 +240,7 @@ jobs:
           path: build/natives
           merge-multiple: true
       - name: Build and Zip Natives
-        run: ./gradlew build zipNatives      
-      - run: |
-          ls -R build/natives/
-          ls -R build/libs/
+        run: ./gradlew build zipNatives
       - name: Publish
         run: ./gradlew -Dorg.gradle.internal.publish.checksums.insecure=true publish -PmavenUser=${artifactoryUser} -PmavenPass=${artifactoryPass}
         env:

--- a/.github/workflows/allInOne.yml
+++ b/.github/workflows/allInOne.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/swig
-          key: ${{ runner.os }}-swig-${{ env.SWIG_VERSION }}
+          key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
       - name: Build and Install SWIG v${{ env.SWIG_VERSION }}
         if: steps.cache-swig.outputs.cache-hit != 'true'
         run: |
@@ -66,7 +66,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/swig
-          key: ${{ runner.os }}-swig-${{ env.SWIG_VERSION }}
+          key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
       - name: Build and Install SWIG v${{ env.SWIG_VERSION }}
         if: steps.cache-swig.outputs.cache-hit != 'true'
         run: |
@@ -111,7 +111,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/swig
-          key: ${{ runner.os }}-swig-${{ env.SWIG_VERSION }}
+          key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
       - name: Build and Install SWIG v${{ env.SWIG_VERSION }}
         if: steps.cache-swig.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/allInOne.yml
+++ b/.github/workflows/allInOne.yml
@@ -12,20 +12,32 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v2
-  build-linux-windows-amd64:
-    runs-on: ubuntu-latest
-    needs: validate-gradle-wrapper
+  build-swig:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-12, macos-14]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Restore SWIG from cache
         id: cache-swig
         uses: actions/cache@v4
         with:
-          path: $GITHUB_WORKSPACE/swig
+          path: ${{ github.workspace }}/swig
           key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
-      - name: Build and Install SWIG v${{ env.SWIG_VERSION }}
+      - name: Install SWIG dependencies
         if: steps.cache-swig.outputs.cache-hit != 'true'
         run: |
-          sudo apt-get install -y autoconf automake libtool
+          if [ "${{ runner.os }}" == 'Linux' ]; then
+            sudo apt-get install -y autoconf automake libtool
+          elif [ "${{ runner.os }}" == 'macOS' ]; then
+            brew install autoconf automake libtool pcre
+          else
+            echo "Unsupported OS: ${{ runner.os }}"
+            exit 1
+          fi
+      - name: Build SWIG v${{ env.SWIG_VERSION }}
+        if: steps.cache-swig.outputs.cache-hit != 'true'
+        run: |
           wget https://github.com/swig/swig/archive/refs/tags/v${{ env.SWIG_VERSION }}.tar.gz
           tar xzf v${{ env.SWIG_VERSION }}.tar.gz
           cd swig-${{ env.SWIG_VERSION }}
@@ -33,6 +45,28 @@ jobs:
           ./configure --prefix=$GITHUB_WORKSPACE/swig
           make
           make install
+      - name: Check SWIG version
+        run: $GITHUB_WORKSPACE/swig/bin/swig -version
+  build-linux-windows-amd64:
+    runs-on: ubuntu-latest
+    needs: [validate-gradle-wrapper, build-swig]
+    steps:
+      - name: Restore SWIG from cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/swig
+          key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
+      # - name: Build and Install SWIG v${{ env.SWIG_VERSION }}
+      #   if: steps.cache-swig.outputs.cache-hit != 'true'
+      #   run: |
+      #     sudo apt-get install -y autoconf automake libtool
+      #     wget https://github.com/swig/swig/archive/refs/tags/v${{ env.SWIG_VERSION }}.tar.gz
+      #     tar xzf v${{ env.SWIG_VERSION }}.tar.gz
+      #     cd swig-${{ env.SWIG_VERSION }}
+      #     ./autogen.sh
+      #     ./configure --prefix=$GITHUB_WORKSPACE/swig
+      #     make
+      #     make install
       - name: Add SWIG to $PATH
         run: |
           echo $GITHUB_WORKSPACE/swig/bin >> $GITHUB_PATH
@@ -60,25 +94,24 @@ jobs:
             build/natives/*/*.dll
   build-macos-amd64:
     runs-on: macos-12
-    needs: validate-gradle-wrapper
+    needs: [validate-gradle-wrapper, build-swig]
     steps:
       - name: Restore SWIG from cache
-        id: cache-swig
         uses: actions/cache@v4
         with:
-          path: $GITHUB_WORKSPACE/swig
+          path: ${{ github.workspace }}/swig
           key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
-      - name: Build and Install SWIG v${{ env.SWIG_VERSION }}
-        if: steps.cache-swig.outputs.cache-hit != 'true'
-        run: |
-          brew install autoconf automake libtool pcre
-          wget https://github.com/swig/swig/archive/refs/tags/v${{ env.SWIG_VERSION }}.tar.gz
-          tar xzf v${{ env.SWIG_VERSION }}.tar.gz
-          cd swig-${{ env.SWIG_VERSION }}
-          ./autogen.sh
-          ./configure --prefix=$GITHUB_WORKSPACE/swig
-          make
-          make install
+      # - name: Build and Install SWIG v${{ env.SWIG_VERSION }}
+      #   if: steps.cache-swig.outputs.cache-hit != 'true'
+      #   run: |
+      #     brew install autoconf automake libtool pcre
+      #     wget https://github.com/swig/swig/archive/refs/tags/v${{ env.SWIG_VERSION }}.tar.gz
+      #     tar xzf v${{ env.SWIG_VERSION }}.tar.gz
+      #     cd swig-${{ env.SWIG_VERSION }}
+      #     ./autogen.sh
+      #     ./configure --prefix=$GITHUB_WORKSPACE/swig
+      #     make
+      #     make install
       - name: Add SWIG to $PATH
         run: |
           echo $GITHUB_WORKSPACE/swig/bin >> $GITHUB_PATH
@@ -106,25 +139,24 @@ jobs:
             build/natives/*/*.dylib
   build-macos-aarch64:
     runs-on: macos-14
-    needs: validate-gradle-wrapper
+    needs: [validate-gradle-wrapper, build-swig]
     steps:
       - name: Restore SWIG from cache
-        id: cache-swig
         uses: actions/cache@v4
         with:
-          path: $GITHUB_WORKSPACE/swig
+          path: ${{ github.workspace }}/swig
           key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
-      - name: Build and Install SWIG v${{ env.SWIG_VERSION }}
-        if: steps.cache-swig.outputs.cache-hit != 'true'
-        run: |
-          brew install autoconf automake libtool pcre
-          wget https://github.com/swig/swig/archive/refs/tags/v${{ env.SWIG_VERSION }}.tar.gz
-          tar xzf v${{ env.SWIG_VERSION }}.tar.gz
-          cd swig-${{ env.SWIG_VERSION }}
-          ./autogen.sh
-          ./configure --prefix=$GITHUB_WORKSPACE/swig
-          make
-          make install
+      # - name: Build and Install SWIG v${{ env.SWIG_VERSION }}
+      #   if: steps.cache-swig.outputs.cache-hit != 'true'
+      #   run: |
+      #     brew install autoconf automake libtool pcre
+      #     wget https://github.com/swig/swig/archive/refs/tags/v${{ env.SWIG_VERSION }}.tar.gz
+      #     tar xzf v${{ env.SWIG_VERSION }}.tar.gz
+      #     cd swig-${{ env.SWIG_VERSION }}
+      #     ./autogen.sh
+      #     ./configure --prefix=$GITHUB_WORKSPACE/swig
+      #     make
+      #     make install
       - name: Add SWIG to $PATH
         run: |
           echo $GITHUB_WORKSPACE/swig/bin >> $GITHUB_PATH

--- a/.github/workflows/allInOne.yml
+++ b/.github/workflows/allInOne.yml
@@ -33,9 +33,10 @@ jobs:
           ./configure --prefix=$HOME/swig
           make
           make install
+      - name: Add SWIG to $PATH
+        run: |
           echo $HOME/swig/bin >> $GITHUB_PATH
-      - name: Check SWIG
-        run: swig -version
+          swig -version
       - name: Install Ming
         run: sudo apt-get install -y mingw-w64
       - uses: actions/checkout@v4
@@ -78,9 +79,10 @@ jobs:
           ./configure --prefix=$HOME/swig
           make
           make install
+      - name: Add SWIG to $PATH
+        run: |
           echo $HOME/swig/bin >> $GITHUB_PATH
-      - name: Check SWIG
-        run: swig -version
+          swig -version
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -123,9 +125,10 @@ jobs:
           ./configure --prefix=$HOME/swig
           make
           make install
+      - name: Add SWIG to $PATH
+        run: |
           echo $HOME/swig/bin >> $GITHUB_PATH
-      - name: Check SWIG
-        run: swig -version
+          swig -version
       - uses: actions/checkout@v4
         with:
           submodules: true

--- a/.github/workflows/allInOne.yml
+++ b/.github/workflows/allInOne.yml
@@ -54,8 +54,7 @@ jobs:
   build:
     strategy:
       matrix:
-        # os:  [ubuntu-latest, macos-12, macos-14]
-        os:  [macos-14]
+        os:  [ubuntu-latest, macos-12, macos-14]
     runs-on: ${{ matrix.os }}
     needs: [validate-gradle-wrapper, swig]
     steps:
@@ -86,14 +85,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Build
-        run: |
-          swig -version
-          which swig
-          echo $SWIG
-          $SWIG -version
-          ./gradlew build buildNatives --info --stacktrace
-        env:
-          SWIG: ${{ github.workspace }}/swig/bin/swig
+        run: ./gradlew build buildNatives
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/allInOne.yml
+++ b/.github/workflows/allInOne.yml
@@ -54,10 +54,14 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12, macos-14]
+        # os:  [ubuntu-latest, macos-12, macos-14]
+        os:  [macos-14]
     runs-on: ${{ matrix.os }}
     needs: [validate-gradle-wrapper, swig]
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Restore SWIG from cache
         uses: actions/cache@v4
         with:
@@ -73,10 +77,7 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install pcre
       - name: Check SWIG version
-        run: swig -version
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
+        run: swig -version      
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -85,7 +86,12 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Build
-        run: ./gradlew build buildNatives --info --stacktrace
+        run: |
+          swig -version
+          which swig
+          echo $SWIG
+          $SWIG -version
+          ./gradlew build buildNatives --info --stacktrace
         env:
           SWIG: ${{ github.workspace }}/swig/bin/swig
       - name: Upload artifacts

--- a/.github/workflows/allInOne.yml
+++ b/.github/workflows/allInOne.yml
@@ -62,8 +62,10 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
           fail-on-cache-miss: true
       - name: Add SWIG to $PATH
+        run: echo "${{ github.workspace }}/swig/bin" >> $GITHUB_PATH
+      - name: Check SWIG version
         run: |
-          echo "${{ github.workspace }}/swig/bin/" >> $GITHUB_PATH
+          which swig
           swig -version
       - name: Install Ming
         run: sudo apt-get install -y mingw-w64
@@ -97,9 +99,11 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
           fail-on-cache-miss: true
       - name: Add SWIG to $PATH
+        run: echo "${{ github.workspace }}/swig/bin" >> $GITHUB_PATH
+      - name: Check SWIG version
         run: |
-          echo "${{ github.workspace }}/swig/bin" >> $GITHUB_PATH
-          brew install pcre
+          brew install prce
+          which swig
           swig -version
       - uses: actions/checkout@v4
         with:
@@ -133,10 +137,11 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
           fail-on-cache-miss: true
       - name: Add SWIG to $PATH
+        run: echo "${{ github.workspace }}/swig/bin" >> $GITHUB_PATH
+      - name: Check SWIG version
         run: |
-          echo "${{ github.workspace }}/swig/bin/" >> $GITHUB_PATH
-          brew install pcre
-          ${{ github.workspace }}/swig/bin/swig -version
+          brew install prce
+          which swig
           swig -version
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/allInOne.yml
+++ b/.github/workflows/allInOne.yml
@@ -18,13 +18,13 @@ jobs:
         os: [ubuntu-latest, macos-12, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Restore SWIG from cache
+      - name: SWIG from cache
         id: cache-swig
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/swig
           key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
-      - name: Install SWIG dependencies
+      - name: Install SWIG build dependencies
         if: steps.cache-swig.outputs.cache-hit != 'true'
         run: |
           if [ "${{ runner.os }}" == 'Linux' ]; then
@@ -45,6 +45,10 @@ jobs:
           ./configure --prefix=$GITHUB_WORKSPACE/swig
           make
           make install
+      - name: Install SWIG runtime dependencies
+        if: runner.os == 'macOs'
+        run: |
+          brew install pcre
       - name: Check SWIG version
         run: $GITHUB_WORKSPACE/swig/bin/swig -version
   build-linux-windows-amd64:
@@ -56,20 +60,10 @@ jobs:
         with:
           path: ${{ github.workspace }}/swig
           key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
-      # - name: Build and Install SWIG v${{ env.SWIG_VERSION }}
-      #   if: steps.cache-swig.outputs.cache-hit != 'true'
-      #   run: |
-      #     sudo apt-get install -y autoconf automake libtool
-      #     wget https://github.com/swig/swig/archive/refs/tags/v${{ env.SWIG_VERSION }}.tar.gz
-      #     tar xzf v${{ env.SWIG_VERSION }}.tar.gz
-      #     cd swig-${{ env.SWIG_VERSION }}
-      #     ./autogen.sh
-      #     ./configure --prefix=$GITHUB_WORKSPACE/swig
-      #     make
-      #     make install
+          fail-on-cache-miss: true
       - name: Add SWIG to $PATH
         run: |
-          echo $GITHUB_WORKSPACE/swig/bin >> $GITHUB_PATH
+          echo "${{ github.workspace }}/swig/bin/" >> $GITHUB_PATH
           swig -version
       - name: Install Ming
         run: sudo apt-get install -y mingw-w64
@@ -101,20 +95,11 @@ jobs:
         with:
           path: ${{ github.workspace }}/swig
           key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
-      # - name: Build and Install SWIG v${{ env.SWIG_VERSION }}
-      #   if: steps.cache-swig.outputs.cache-hit != 'true'
-      #   run: |
-      #     brew install autoconf automake libtool pcre
-      #     wget https://github.com/swig/swig/archive/refs/tags/v${{ env.SWIG_VERSION }}.tar.gz
-      #     tar xzf v${{ env.SWIG_VERSION }}.tar.gz
-      #     cd swig-${{ env.SWIG_VERSION }}
-      #     ./autogen.sh
-      #     ./configure --prefix=$GITHUB_WORKSPACE/swig
-      #     make
-      #     make install
+          fail-on-cache-miss: true
       - name: Add SWIG to $PATH
         run: |
-          echo $GITHUB_WORKSPACE/swig/bin >> $GITHUB_PATH
+          echo "${{ github.workspace }}/swig/bin" >> $GITHUB_PATH
+          brew install pcre
           swig -version
       - uses: actions/checkout@v4
         with:
@@ -146,20 +131,12 @@ jobs:
         with:
           path: ${{ github.workspace }}/swig
           key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
-      # - name: Build and Install SWIG v${{ env.SWIG_VERSION }}
-      #   if: steps.cache-swig.outputs.cache-hit != 'true'
-      #   run: |
-      #     brew install autoconf automake libtool pcre
-      #     wget https://github.com/swig/swig/archive/refs/tags/v${{ env.SWIG_VERSION }}.tar.gz
-      #     tar xzf v${{ env.SWIG_VERSION }}.tar.gz
-      #     cd swig-${{ env.SWIG_VERSION }}
-      #     ./autogen.sh
-      #     ./configure --prefix=$GITHUB_WORKSPACE/swig
-      #     make
-      #     make install
+          fail-on-cache-miss: true
       - name: Add SWIG to $PATH
         run: |
-          echo $GITHUB_WORKSPACE/swig/bin >> $GITHUB_PATH
+          echo "${{ github.workspace }}/swig/bin/" >> $GITHUB_PATH
+          brew install pcre
+          ${{ github.workspace }}/swig/bin/swig -version
           swig -version
       - uses: actions/checkout@v4
         with:

--- a/README.md
+++ b/README.md
@@ -4,28 +4,25 @@ TeraBullet is a version of bullet with extensions for direct interactions for vo
 
 ## Prerequisites
 
+Make sure the following applications are installed:
+
+- Java 11 or later
+- [CMake](https://cmake.org/)
+- [SWIG](https://www.swig.org/) v4.0.2
+- [MinGW-w64](https://www.mingw-w64.org/) (cross-compilation for Windows on Linux)
+
 Clone this repository and initialize all git submodules:
 
 ```sh
 git submodule update --init --recursive
 ```
 
-Install Java 11 or later.
-
-## Linux (for Linux and Windows artifacts)
-
-Install `swig`, `cmake` and `mingw-w64`.
-
-## MacOS
-
-Install `swig` and `cmake`.
-
 ## Build
 
-To build all natives for the current platform run
+To build the Java library and all supported natives for the current platform run
 
 ```sh
-./gradlew buildNatives
+./gradlew build buildNatives
 ```
 
 The native libraries are written to `build/natives/*` and are `.so`, `dll`, or `.dylib` files.
@@ -36,7 +33,7 @@ To see a list of all known natives (platforms and operating systems), run
 ./gradlew listNatives
 ```
 
-To build the Java library part of bullet, simply run 
+To build only the Java library part of bullet, simply run 
 
 ```
 ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,15 @@ plugins {
 import org.apache.tools.ant.taskdefs.condition.Os
 ext {
     if(Os.isFamily(Os.FAMILY_MAC)) {
-        natives = ["macosx_amd64_clang","macosx_aarch64_clang"]
+        // Compilation succeeds for both targets on either Mac platform, but in both cases the output is for the platform we're on
+        // Therefore, we only include our own platform as target here.
+        if (Os.isArch("aarch64")) {
+            natives = ["macosx_aarch64_clang"]
+        } else {
+            natives = ["macosx_amd64_clang"]
+        }        
     } else if (Os.isFamily(Os.FAMILY_UNIX)) {
+        // Cross-compilation with MinGW-w64 allows us to also build the Windows target on Linux
         natives = ["linux_amd64_gcc","linux_windows_amd64_mingw32"]
     } else {
         throw new GradleException("This script only works on Linux or Mac")

--- a/swig-src/build.gradle
+++ b/swig-src/build.gradle
@@ -2,10 +2,16 @@ ext {
     swigTarget = ["linearmath","collision","dynamics","softbody","extras","inversedynamics"]
 }
 
+def swigBinary = System.getenv()["SWIG"] != null ? System.getenv()["SWIG"] : "swig"
+
+project.exec {
+    commandLine 'env'
+}
+
 swigTarget.each { module ->
     tasks.create(name: "swig_"+"${module}", type: Exec) {
         description = 'Swigging collision'
-        executable "swig"
+        executable swigBinary
         args ("-java",
                 "-c++",
                 "-Wall",

--- a/swig-src/build.gradle
+++ b/swig-src/build.gradle
@@ -2,16 +2,10 @@ ext {
     swigTarget = ["linearmath","collision","dynamics","softbody","extras","inversedynamics"]
 }
 
-def swigBinary = System.getenv()["SWIG"] != null ? System.getenv()["SWIG"] : "swig"
-
-project.exec {
-    commandLine 'env'
-}
-
 swigTarget.each { module ->
     tasks.create(name: "swig_"+"${module}", type: Exec) {
         description = 'Swigging collision'
-        executable swigBinary
+        executable "swig"
         args ("-java",
                 "-c++",
                 "-Wall",


### PR DESCRIPTION
This PR builds SWIG in version 4.0.2 from source on all platforms to ensure we're using the same version of SWIG to avoid linking issues (as we've seen on Mac while testing).

We're using v4.0.2 because of #18.

You can find a [successful run](https://github.com/skaldarnar/JNBullet/actions/runs/8318015794) producing a (better looking) artifact [1.0.4-20240317.202106-7](https://artifactory.terasology.io/ui/packages/gav:%2F%2Forg.terasology.jnbullet:JNBullet/1.0.4-20240317.202106-7?name=jnbullet&type=packages).

![grafik](https://github.com/MovingBlocks/JNBullet/assets/1448874/d377f386-2465-4b00-b302-00d84e906731)
