### PR TITLE
fix(ci): build Linux natives against a pinned glibc floor

### DIFF
--- a/.github/workflows/allInOne.yml
+++ b/.github/workflows/allInOne.yml
@@ -18,6 +18,13 @@ name: Build and Publish for all Platforms
 
 on: [push]
 
+# Container jobs default to `sh`, not `bash` -- GitHub cannot assume bash exists in an
+# arbitrary image. The steps below use `==` and other bashisms, so pin the shell rather
+# than rewrite them to be POSIX-portable.
+defaults:
+  run:
+    shell: bash
+
 env:
   SWIG_VERSION: 4.0.2
   LLVM_MINGW_VERSION: 20260616

--- a/.github/workflows/allInOne.yml
+++ b/.github/workflows/allInOne.yml
@@ -130,7 +130,11 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}-v${{ env.SWIG_CACHE_VERSION }}
           fail-on-cache-miss: true
       - name: Add SWIG to $PATH
-        run: echo "${{ github.workspace }}/swig/bin" >> $GITHUB_PATH
+        # $GITHUB_WORKSPACE, not ${{ github.workspace }}: the expression resolves to the
+        # host path, which does not exist inside a container. The env var is set per
+        # environment. actions/cache maps the two itself, so its `path:` input is fine
+        # either way -- a plain run step is not.
+        run: echo "$GITHUB_WORKSPACE/swig/bin" >> $GITHUB_PATH
       - name: Install libpcre3
         if: runner.os == 'Linux'
         run: sudo apt-get install -y libpcre3-dev
@@ -193,7 +197,11 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}-v${{ env.SWIG_CACHE_VERSION }}
           fail-on-cache-miss: true
       - name: Add SWIG to $PATH
-        run: echo "${{ github.workspace }}/swig/bin" >> $GITHUB_PATH
+        # $GITHUB_WORKSPACE, not ${{ github.workspace }}: the expression resolves to the
+        # host path, which does not exist inside a container. The env var is set per
+        # environment. actions/cache maps the two itself, so its `path:` input is fine
+        # either way -- a plain run step is not.
+        run: echo "$GITHUB_WORKSPACE/swig/bin" >> $GITHUB_PATH
       - name: Install libpcre3
         run: sudo apt-get install -y libpcre3-dev
       - name: Check SWIG version

--- a/.github/workflows/allInOne.yml
+++ b/.github/workflows/allInOne.yml
@@ -9,12 +9,20 @@ name: Build and Publish for all Platforms
 # Terasology ships these natives to players. Building on the runner directly leaves
 # that floor to drift upward silently every time GitHub retires a runner image.
 #
-# ubuntu:22.04 pins it at glibc 2.35. Anything at or above that -- Debian 12,
-# Ubuntu 22.04, RHEL 9 -- can load the result. Raising this image drops distros for
-# downstream users; do it on purpose, not as a side effect of a runner bump.
+# Two different numbers are involved and it is worth keeping them apart. The build
+# image supplies glibc 2.35, but that is only a ceiling -- what actually constrains
+# consumers is the highest GLIBC_* symbol version the linker ends up referencing,
+# which today is 2.34 (the release that folded libpthread and libdl into libc).
+# GLIBC_FLOOR in the build job asserts that measured value, not the image's, so a
+# change that started pulling in 2.35 symbols fails rather than quietly narrowing
+# who can run the result.
 #
-# It also has to stay at or above 22.04 while LLVM_MINGW_VERSION is pinned to an
-# ubuntu-22.04 build, since that cross-compiler runs in the same job.
+# At 2.34 the natives load on Debian 12, Ubuntu 22.04, and RHEL 9. Raising either
+# number drops distros for downstream users; do it on purpose, not as a side effect
+# of a runner bump.
+#
+# The image also has to stay at or above 22.04 while LLVM_MINGW_VERSION is pinned to
+# an ubuntu-22.04 build, since that cross-compiler runs in the same job.
 
 on: [push]
 
@@ -45,8 +53,8 @@ jobs:
     strategy:
       matrix:
         include:
-          # Built inside the same image the natives are, so the cached binary runs
-          # in the container and on the plain runner the publish job uses.
+          # Built inside the same image the natives are, so the cached binary runs in
+          # every Linux job that consumes it -- both build and publish are containers.
           - os: ubuntu-24.04
             container: ubuntu:22.04
           - os: ubuntu-24.04-arm
@@ -170,12 +178,27 @@ jobs:
         # CMakeLists.txt links libgcc and libstdc++ statically.
         if: matrix.container != ''
         env:
-          GLIBC_FLOOR: '2.35'
+          # The measured requirement of the built natives, not the build image's glibc.
+          # See the note at the top of this file for why those differ.
+          GLIBC_FLOOR: '2.34'
         run: |
-          required=$(objdump -T build/natives/linux_*_gcc/*.so | grep -o 'GLIBC_[0-9]\+\.[0-9]\+' | sed 's/GLIBC_//' | sort -uV)
+          natives=$(ls build/natives/linux_*_gcc/*.so 2>/dev/null || true)
+          if [ -z "$natives" ]; then
+            echo "::error::No Linux natives found under build/natives/linux_*_gcc/ — nothing to check."
+            exit 1
+          fi
+          if ! symbols=$(objdump -T $natives); then
+            echo "::error::objdump could not read the built natives."
+            exit 1
+          fi
+          required=$(printf '%s\n' "$symbols" | grep -o 'GLIBC_[0-9]\+\.[0-9]\+' | sed 's/GLIBC_//' | sort -uV || true)
+          if [ -z "$required" ]; then
+            echo "::error::No GLIBC_* symbol versions found — the floor is unverified, which is not the same as satisfied."
+            exit 1
+          fi
           echo "glibc symbol versions required by the built natives:"
-          echo "$required" | sed 's/^/  /'
-          highest=$(echo "$required" | tail -1)
+          printf '%s\n' "$required" | sed 's/^/  /'
+          highest=$(printf '%s\n' "$required" | tail -1)
           if [ "$(printf '%s\n%s\n' "$GLIBC_FLOOR" "$highest" | sort -V | tail -1)" != "$GLIBC_FLOOR" ]; then
             echo "::error::Natives require glibc $highest, above the declared floor of $GLIBC_FLOOR. See the note at the top of this workflow."
             exit 1

--- a/.github/workflows/allInOne.yml
+++ b/.github/workflows/allInOne.yml
@@ -1,10 +1,31 @@
 name: Build and Publish for all Platforms
 
+# The Linux natives are compiled inside a container (`container: ubuntu:22.04` in the
+# swig and build jobs below), not directly on the runner. That is deliberate.
+#
+# CMakeLists.txt already links libgcc and libstdc++ statically, so glibc is the only
+# remaining dynamic dependency of the published .so -- which makes the build host's
+# glibc the *minimum supported Linux* for everything that consumes JNBullet, and
+# Terasology ships these natives to players. Building on the runner directly leaves
+# that floor to drift upward silently every time GitHub retires a runner image.
+#
+# ubuntu:22.04 pins it at glibc 2.35. Anything at or above that -- Debian 12,
+# Ubuntu 22.04, RHEL 9 -- can load the result. Raising this image drops distros for
+# downstream users; do it on purpose, not as a side effect of a runner bump.
+#
+# It also has to stay at or above 22.04 while LLVM_MINGW_VERSION is pinned to an
+# ubuntu-22.04 build, since that cross-compiler runs in the same job.
+
 on: [push]
 
 env:
   SWIG_VERSION: 4.0.2
   LLVM_MINGW_VERSION: 20260616
+  # Part of every SWIG cache key. Bump it whenever the environment SWIG is built
+  # in changes: the cached binary is linked against that environment's glibc and
+  # pcre, so a stale entry restores a binary that cannot run. Bumped to 2 when the
+  # Linux jobs moved into a container.
+  SWIG_CACHE_VERSION: 2
 
 jobs:
   validate-gradle-wrapper:
@@ -16,15 +37,35 @@ jobs:
   swig:
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-26-intel, macos-26]
+        include:
+          # Built inside the same image the natives are, so the cached binary runs
+          # in the container and on the plain runner the publish job uses.
+          - os: ubuntu-24.04
+            container: ubuntu:22.04
+          - os: ubuntu-24.04-arm
+            container: ubuntu:22.04
+          - os: macos-26-intel
+          - os: macos-26
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     steps:
+      - name: Prepare container
+        if: matrix.container != ''
+        # The image is bare: no git for checkout, no sudo for the apt steps below,
+        # no toolchain. Runs before every other step for that reason. bison is
+        # needed because we build SWIG from a git tag archive rather than a release
+        # tarball, so its parser is not pre-generated; the hosted runners happen to
+        # ship it preinstalled and this image does not.
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            bison build-essential ca-certificates curl git sudo wget xz-utils
       - name: SWIG from cache
         id: cache-swig
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/swig
-          key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
+          key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}-v${{ env.SWIG_CACHE_VERSION }}
       - name: Install SWIG dependencies
         # Always install, even on a cache hit: this also provides the pcre runtime
         # library the cached swig binary is linked against, which isn't persisted
@@ -53,10 +94,25 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-26-intel, macos-26]
+        include:
+          # Linux natives build in the container, not on the runner -- see the
+          # glibc-floor note at the top of this file before changing the image.
+          - os: ubuntu-24.04
+            container: ubuntu:22.04
+          - os: ubuntu-24.04-arm
+            container: ubuntu:22.04
+          - os: macos-26-intel
+          - os: macos-26
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     needs: [validate-gradle-wrapper, swig]
     steps:
+      - name: Prepare container
+        if: matrix.container != ''
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential ca-certificates cmake curl git sudo unzip wget xz-utils
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -64,7 +120,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/swig
-          key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
+          key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}-v${{ env.SWIG_CACHE_VERSION }}
           fail-on-cache-miss: true
       - name: Add SWIG to $PATH
         run: echo "${{ github.workspace }}/swig/bin" >> $GITHUB_PATH
@@ -106,9 +162,20 @@ jobs:
             build/natives/*/*.dylib
   publish:
     runs-on: ubuntu-24.04
+    # Same container as the Linux build jobs. Not for the ABI floor -- this job only
+    # repackages natives built elsewhere -- but because SWIG bakes its --prefix in at
+    # configure time. The cached binary looks for its runtime library under the
+    # workspace path it was configured with, and that path differs between a
+    # container job and a host job.
+    container: ubuntu:22.04
     needs: [validate-gradle-wrapper, swig, build]
     if: github.ref == 'refs/heads/master'
     steps:
+      - name: Prepare container
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential ca-certificates curl git sudo unzip wget xz-utils
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -116,7 +183,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/swig
-          key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}
+          key: ${{ runner.os }}-${{ runner.arch }}-swig-${{ env.SWIG_VERSION }}-v${{ env.SWIG_CACHE_VERSION }}
           fail-on-cache-miss: true
       - name: Add SWIG to $PATH
         run: echo "${{ github.workspace }}/swig/bin" >> $GITHUB_PATH

--- a/.github/workflows/allInOne.yml
+++ b/.github/workflows/allInOne.yml
@@ -163,6 +163,24 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
       - name: Build
         run: ./gradlew build buildNatives
+      - name: Check the glibc floor of the Linux natives
+        # Turns the container choice into something enforced rather than assumed. If a
+        # future change builds these on a newer base, this fails here instead of as an
+        # UnsatisfiedLinkError on a user's machine. Only glibc is checked because
+        # CMakeLists.txt links libgcc and libstdc++ statically.
+        if: matrix.container != ''
+        env:
+          GLIBC_FLOOR: '2.35'
+        run: |
+          required=$(objdump -T build/natives/linux_*_gcc/*.so | grep -o 'GLIBC_[0-9]\+\.[0-9]\+' | sed 's/GLIBC_//' | sort -uV)
+          echo "glibc symbol versions required by the built natives:"
+          echo "$required" | sed 's/^/  /'
+          highest=$(echo "$required" | tail -1)
+          if [ "$(printf '%s\n%s\n' "$GLIBC_FLOOR" "$highest" | sort -V | tail -1)" != "$GLIBC_FLOOR" ]; then
+            echo "::error::Natives require glibc $highest, above the declared floor of $GLIBC_FLOOR. See the note at the top of this workflow."
+            exit 1
+          fi
+          echo "OK: highest requirement $highest is within the declared floor $GLIBC_FLOOR."
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://github.com/SiliconSaga/yggdrasil).

## Summary

- Builds the Linux natives inside `ubuntu:22.04` instead of directly on the runner, so their glibc floor is a pinned decision rather than a side effect of whichever runner image GitHub currently offers.
- Adds a step that reads the symbol versions back off the built `.so` and fails if any exceeds the declared floor — the regression this fixes was only discovered downstream, in someone else's CI.
- Three smaller fixes that containerising surfaced: container jobs default to `sh` rather than `bash`; `${{ github.workspace }}` resolves to the host path inside a container while `$GITHUB_WORKSPACE` resolves per environment; SWIG cache keys need a version component because the cached binary is linked against the environment it was built in.

## Why

`CMakeLists.txt` already links libgcc and libstdc++ statically, so glibc is the only remaining dynamic dependency of the published `.so`. That makes the build host's glibc the **minimum supported Linux for every consumer** — and Terasology copies these natives straight into its player distribution (`facades/PC/build.gradle.kts`).

#23 moved the Linux matrix from `ubuntu-20.04` to `ubuntu-24.04` to replace runner images GitHub had retired. That was necessary, but it raised the floor from glibc 2.31 to 2.39 as a side effect, and nothing in the build declares or checks a floor. The result cannot load on anything older:

```
UnsatisfiedLinkError: .../libbullet-linux-amd64.so:
  /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found
```

That is MovingBlocks/Terasology#5359, where every engine test fails on Debian-based build agents once the static initialiser dies. It would equally affect any player below Ubuntu 24.04.

A container rather than an older runner label, for two reasons: there is no `ubuntu-20.04-arm` or equivalent, so the `linux_aarch64` target added in #23 cannot reach a low floor via `runs-on` at all; and pinning the image is what stops the next runner retirement from moving the floor again silently.

`ubuntu:22.04` specifically, rather than something older, because `LLVM_MINGW_VERSION` is pinned to an ubuntu-22.04 build of llvm-mingw which runs in the same job. Going lower would mean splitting the Windows cross-compile targets into a separate job.

Note the image's glibc and the resulting floor are different numbers. The image supplies 2.35, but the linker only ends up referencing symbols up to **2.34** (the release that folded libpthread and libdl into libc), and 2.34 is what the check asserts — so the natives load on Debian 12, Ubuntu 22.04, and RHEL 9. It does drop Ubuntu 20.04 and Debian 11 relative to 1.0.4 — both past end of standard support — so if you would rather keep those, say so and I will split the job and drop the image to `ubuntu:20.04`.

## Test plan

- [x] Full workflow green on a fork, all four platforms, on both the original and the post-review revision: https://github.com/SiliconSaga/JNBullet/actions/runs/31535955686
- [x] The check reports the actual floor rather than assuming it — `objdump -T` on the built natives yields a highest requirement of `2.34` on both amd64 and aarch64, exactly the declared floor.
- [x] Verified the check fails closed: it compares against the highest observed symbol version and treats "no versions found" as unverified rather than passing. With `GLIBC_FLOOR` now at the measured value there is deliberately zero headroom, so any increase fails the job.
- [ ] Needs a merge to `master` to republish `1.0.5-SNAPSHOT`; the publish job is gated on `github.ref`, so a green PR build alone does not refresh the artifact.
- [ ] After that, re-run MovingBlocks/Terasology#5359 — no version change needed there, since `1.0.5-SNAPSHOT` is a changing module and the agents start cold.

## Related

- Regression from #23
- Downstream failure: MovingBlocks/Terasology#5359
